### PR TITLE
header-with-timezone-offset

### DIFF
--- a/oc-columbus-header/package.json
+++ b/oc-columbus-header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oc-columbus-header",
   "description": "A header for a website with logo and title",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mattiaerre/oc-hub/tree/master/oc-columbus-header"

--- a/oc-columbus-header/server.js
+++ b/oc-columbus-header/server.js
@@ -5,7 +5,13 @@ export const data = (context, callback) => {
       url: context.params.logoUrl,
       alt: `${context.params.title} logo`,
     },
-    title: context.params.title
+    title: context.params.title,
+    timezoneOffset: '?'
   };
+
+  if (context.plugins.getTimezoneOffset) {
+    model.timezoneOffset = context.plugins.getTimezoneOffset();
+  }
+
   callback(null, model);
 };

--- a/oc-columbus-header/template.jade
+++ b/oc-columbus-header/template.jade
@@ -1,4 +1,4 @@
-div.oc-columbus-header
+div.oc-columbus-header(data-timezone-offset= timezoneOffset)
   div.logo
     a(href= logo.href)
       img(src= logo.url alt= logo.alt)

--- a/oc.json
+++ b/oc.json
@@ -1,4 +1,11 @@
 {
+  "mocks": {
+    "plugins": {
+      "dynamic": {
+        "getTimezoneOffset": "./plugins/timezone-offset-mock.js"
+      }
+    }
+  },
   "registries": [
     "https://pink-pineapple.herokuapp.com/"
   ]

--- a/plugins/timezone-offset-mock.js
+++ b/plugins/timezone-offset-mock.js
@@ -1,0 +1,1 @@
+module.exports = () => (new Date().getTimezoneOffset());


### PR DESCRIPTION
# Description

`oc-columbus-header` has got now a `data-timezone-offset` attribute set by the `getTimezoneOffset` plugin if available at the registry level